### PR TITLE
fix: Resolve read progress upsert issue for unread chapters

### DIFF
--- a/src/renderer/components/HomeComponents/HomeDashboardComponents/HomeDashboardListItem.tsx
+++ b/src/renderer/components/HomeComponents/HomeDashboardComponents/HomeDashboardListItem.tsx
@@ -41,7 +41,6 @@ const HomeDashboardComicListItem = ({ item }: { item: IChapter }): React.JSX.Ele
   const mutation = useMutation({
     mutationFn: async (page: number) => {
       const ReadProgress = item.ReadProgress?.[0]
-      if (!ReadProgress) return
       await invoke('dbUpdateReadProgress', {
         readProgress: {
           ...ReadProgress,


### PR DESCRIPTION
## Problem

The read/unread buttons in the dashboard only worked for chapters that had been opened at least once. For chapters that hadn't been read yet, clicking the buttons would do nothing because there was no read progress record in the database.

## Root Cause

In `HomeDashboardListItem.tsx`, the mutation function had an early return when `ReadProgress` was undefined:

```typescript
const ReadProgress = item.ReadProgress?.[0]
if (!ReadProgress) return  // ❌ This prevented creating new read progress records
```

## Solution

Removed the early return to allow the existing upsert logic in `DBRepository.ts` to work properly:

```typescript
const ReadProgress = item.ReadProgress?.[0]
// ✅ Now it continues to the dbUpdateReadProgress call
await invoke('dbUpdateReadProgress', {
  readProgress: {
    ...ReadProgress,  // undefined is fine here
    chapterId: item.id,
    comicId: item.comicId,
    userId: currentUser.id,
    totalPages,
    page
  }
})
```

## How It Works

1. **When chapter has no read progress**: `ReadProgress` is `undefined`, but the spread operator `...ReadProgress` safely handles this
2. **The existing DBRepository logic** already handles upsert correctly:
   - If `readProgress.id` is undefined → creates new record
   - If `readProgress.id` exists → updates existing record
3. **Reader.tsx** already had correct upsert logic implemented

## Testing

- ✅ Type checking passes
- ✅ Linting passes  
- ✅ Read/unread buttons now work for chapters without existing progress
- ✅ No breaking changes

## Files Changed

- `src/renderer/components/HomeComponents/HomeDashboardComponents/HomeDashboardListItem.tsx`

Fixes the issue where mark as read/unread buttons only worked after opening chapter once.
