### PR TITLE
feat: Move About page to Settings as a tab

### DIFF
--- a/src/renderer/components/HomeComponents/HomeNav.tsx
+++ b/src/renderer/components/HomeComponents/HomeNav.tsx
@@ -32,7 +32,7 @@ const HomeNav = (): React.JSX.Element => {
     {
       label: t('HomeNav.about'),
       icon: infoIcon,
-      onClick: (): void => openWindow({ component: 'About', props: {} })
+      onClick: (): void => openWindow({ component: 'Settings', props: { initialTab: 'about' } })
     },
     {
       label: t('HomeNav.settings'),

--- a/src/renderer/components/SettingsComponents/SettingsAbout.tsx
+++ b/src/renderer/components/SettingsComponents/SettingsAbout.tsx
@@ -1,0 +1,51 @@
+import useApi from 'api'
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import Image from 'components/Image'
+import LoadingOverlay from 'components/LoadingOverlay'
+
+import appIcon from 'assets/icon.svg'
+
+const SettingsAbout = (): React.JSX.Element => {
+  const { invoke } = useApi()
+  const { t } = useTranslation()
+  const { data: appData, isLoading: appDataLoading } = useQuery({
+    queryKey: ['appData'],
+    queryFn: async () => await invoke('getAppData')
+  })
+
+  const { data: appVersion, isLoading: versionLoading } = useQuery({
+    queryKey: ['appVersion'],
+    queryFn: async () => await invoke('getAppVersion')
+  })
+
+  const isLoading = appDataLoading || versionLoading
+
+  return (
+    <div className="flex-grow h-full flex flex-col items-center justify-center text-center gap-1 p-8">
+      <LoadingOverlay isLoading={isLoading} />
+      <Image src={appIcon} className="w-1/3 aspect-square flex-shrink-0" />
+      <div className="flex flex-grow h-full flex-col items-center justify-center text-center gap-1">
+        <h1 className="text-3xl">Comic Universe</h1>
+        <p>
+          {t('General.version')}: {appVersion || appData?.version}
+        </p>
+        <p>
+          {t('General.author')}: {appData?.author}
+        </p>
+        <p>
+          {t('General.license')}: {appData?.license}
+        </p>
+        {/* eslint-disable-next-line prettier/prettier */}
+        {appData?.description
+          .split('. ')
+          .map((description) => <p key={description}>{description}.</p>)}
+        <a href={appData?.repository} target="_blank" rel="noreferrer" className="mt-2">
+          <u>{t('General.githubRepository')}</u>
+        </a>
+      </div>
+    </div>
+  )
+}
+
+export default SettingsAbout

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -3,14 +3,16 @@ import SettingsList from 'components/SettingsComponents/SettingsList'
 import SettingsGeneral from 'components/SettingsComponents/SettingsGeneral'
 import SettingsUser from 'components/SettingsComponents/SettingsUser'
 import SettingsPlugin from 'components/SettingsComponents/SettingsPlugin'
+import SettingsAbout from 'components/SettingsComponents/SettingsAbout'
 import { useTranslation } from 'react-i18next'
 
 import pluginIcon from 'assets/plugin.svg'
 import userIcon from 'assets/user.svg'
 import settingsIcon from 'assets/settings.svg'
+import infoIcon from 'assets/info.svg'
 
-const Settings = (): ReactElement => {
-  const [activeOption, setActiveOption] = useState('general')
+const Settings = ({ initialTab }: { initialTab?: string }): ReactElement => {
+  const [activeOption, setActiveOption] = useState(initialTab || 'general')
 
   const { t } = useTranslation()
 
@@ -32,17 +34,26 @@ const Settings = (): ReactElement => {
       icon: pluginIcon,
       tag: 'plugins',
       onClick: () => setActiveOption('plugins')
+    },
+    {
+      label: t('HomeNav.about'),
+      icon: infoIcon,
+      tag: 'about',
+      onClick: () => setActiveOption('about')
     }
   ]
 
   useEffect(() => {
-    setActiveOption(settingsOptions[0].tag)
-  }, [])
+    if (!initialTab) {
+      setActiveOption(settingsOptions[0].tag)
+    }
+  }, [initialTab])
 
   const componentList = {
     general: SettingsGeneral,
     user: SettingsUser,
-    plugins: SettingsPlugin
+    plugins: SettingsPlugin,
+    about: SettingsAbout
   }
 
   const Components = componentList[activeOption]


### PR DESCRIPTION
## Summary

This PR moves the About page functionality into the Settings window as a new tab, consolidating the UI and improving user experience.

## Changes

### ✨ New Features
- **About Tab in Settings**: Added a new About tab to the Settings window
- **Integrated About Content**: Moved all About page content (version, author, license, description, repository link) into the Settings About tab
- **Smart Menu Integration**: About button in the menu now opens Settings directly on the About tab

### 🔧 Technical Changes
- Created  component with the same functionality as the original About page
- Updated  to support an  prop for opening specific tabs
- Modified  to open Settings with About tab instead of separate About window
- Reduced logo size in About tab to prevent scrolling and improve layout

### 📁 Files Changed
-  (new)
-  (updated)
-  (updated)

## Benefits

1. **Consolidated UI**: All settings and app information in one place
2. **Better UX**: No need to manage separate About window
3. **Consistent Design**: About content follows Settings design patterns
4. **Space Efficient**: Smaller logo prevents scrolling issues

## Testing

- [x] About tab appears in Settings
- [x] About button opens Settings on About tab
- [x] All About content displays correctly (version, author, license, etc.)
- [x] No scrolling issues with optimized logo size
- [x] Regular Settings functionality still works

## Screenshots

The About content is now integrated as the 4th tab in Settings, accessible via the info icon.